### PR TITLE
Remove p tag surrounding the breadcrumb condition in item.html.

### DIFF
--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -7,11 +7,11 @@
 {% set datestamp = include('partials/page-bits/date.html.twig') %}
 
 {% block content %}
-    <p>
+
     {% if show_breadcrumbs and config.plugins.breadcrumbs.enabled %}
         {% include 'partials/breadcrumbs.html.twig' %}
     {% endif %}
-    </p>
+
 <article itemscope itemtype="http://schema.org/Article">
     <header>
         {% if show_title %}<h1 itemprop="name headline">{{ title }}</h1>{% endif %}


### PR DESCRIPTION
@pmoreno-rodriguez 

I realised some headings are very low on the page, because of an empty html paragraph:

![image](https://github.com/user-attachments/assets/90102866-58de-43b1-9a93-01cda6812cb4)

This comes from the [item.html.twig](https://github.com/pmoreno-rodriguez/grav-theme-editorial/blob/9c1c39adda437e47561fba71ca4e33d925b04667/templates/item.html.twig#L10), where a p tag is surrounding the breadcrumb feature.

This pull request temoves the p tags, so it's like in the [blog.html.twig](https://github.com/pmoreno-rodriguez/grav-theme-editorial/blob/9c1c39adda437e47561fba71ca4e33d925b04667/templates/blog.html.twig#L23).

Result:

![image](https://github.com/user-attachments/assets/b5c6c123-bdbc-446e-8ac4-165dbd173fb9)

