### PR TITLE
Update featured-posts.html.twig

### DIFF
--- a/templates/partials/sidebar/featured-posts.html.twig
+++ b/templates/partials/sidebar/featured-posts.html.twig
@@ -11,7 +11,7 @@
     {% if featured.count > 0 %}
         <div class="mini-posts">
             {% for p in featured.slice(0,featured_number) %}
-            {% set image = p.media[p.header.featured_image] ?: page.media.images|first %}
+            {% set image = p.media[p.header.featured_image] ?: p.media.images|first %}
             {% set title = p.title|raw %}
             {% if page.url != p.url %}
                 <article>


### PR DESCRIPTION
Proposed change will now correctly display the first image of the actual blog item page in the "featured posts" part of the sidebar, instead of wrongly displaying the first image of whatever other page the sidebar is shown.